### PR TITLE
Milestone II: Testing To Do list: part 2

### DIFF
--- a/src/tests/form.test.js
+++ b/src/tests/form.test.js
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+import TodoList from "../modules/todoList";
+import Form from "../modules/form";
+
+document.body.innerHTML =
+  `
+    <div> 
+        <ul id="test-list"></ul> 
+    </div>
+    <div class="box"> 
+        <input id="new_task_input" placeholder="Add to your list..." type="text"> 
+        <i id="new_task_icon" class="fa-solid fa-arrow-turn-down fa-rotate-90 fa-2xs"></i>
+    </div>
+    <button class="box" id="clear_all_completed_tasks">
+        <span>Clear all completed</span>
+    </button>
+  `;
+
+const myList = new TodoList('#test-list');
+
+const myForm = new Form(myList, {
+  newTaskInput: 'new_task_input',
+  newTaskIcon: 'new_task_icon',
+  clearAllCompletedTasks: 'clear_all_completed_tasks',
+});
+
+const testEventStorage = new Map();
+
+let testEventOutput = 0;
+
+const testEvent = {
+    dataTransfer: {
+      setData: (key, value) => testEventStorage.set(key, value),
+      getData: (key) => testEventStorage.get(key)
+    },
+    preventDefault: () => testEventOutput = 1
+};
+
+describe('Optional requirements', () => {
+    test('Add event must create new task', () => {
+        const event = { key: 'Enter', type: 'click' }
+
+        Form.addInput = { value: 'just a test' };
+        Form.addEvent(event);
+        
+        expect(Form.list.tasks).toHaveLength(1);
+    });
+
+    test('Remove event must remove task', () => {
+        Form.index = 1;
+        Form.removeEvent();
+        
+        expect(Form.list.tasks).toHaveLength(0);
+    });
+
+    test('toggleCompleted event must change task complete status', () => {
+        const event = { key: 'Enter', type: 'click' }
+
+        Form.addInput = { value: 'just a test' };
+        Form.addEvent(event);
+
+        const toggleEvent = { currentTarget: { checked: true } };
+
+        Form.list.tasks[0].completed = true;
+
+        Form.toggleCompleted(toggleEvent)
+
+        expect(Form.list.tasks[0].domCheck.checked).toBe(true);
+    });
+
+    test('toggleCompleted event must change task complete status', () => {
+        const event = { key: 'Enter', type: 'click' }
+
+        Form.addInput = { value: 'just a test 2' };
+        Form.addEvent(event);
+
+        const toggleEvent = { currentTarget: { checked: false } };
+
+        Form.list.tasks[0].completed = false;
+
+        Form.toggleCompleted(toggleEvent)
+
+        expect(Form.list.tasks[0].domCheck.checked).toBe(false);
+    });
+
+    test('edit event must add .editing css class', () => {
+        Form.editing = false;
+        Form.domElement = Form.list.tasks[0].domElement;
+        Form.domInput = Form.list.tasks[0].domInput;
+        Form.domSpan = Form.list.tasks[0].domSpan;
+
+        Form.editEvent();
+
+        expect(Form.editing).toBe(true);
+        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
+    });
+
+    test('edit event must do nothing when already editing', () => {
+        Form.editing = true;
+
+        Form.editEvent();
+
+        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
+    });
+
+    test('dragTask must set index value', () => {
+        Form.dragTask(testEvent);
+
+        expect(testEvent.dataTransfer.getData('index')).toBe(1);
+        
+    });
+
+    test('allowDropTask must prevent Default behavior', () => {
+        Form.allowDropTask(testEvent)
+        expect(testEventOutput).toBe(1);
+    });
+
+    test('dropTask must switch item index', () => {
+        Form.index = 2;
+        Form.dropTask(testEvent);
+        expect(Form.list.tasks[0].description).toBe('just a test 2');     
+        expect(Form.list.tasks[1].description).toBe('just a test');     
+    });
+
+    test('keypress enter event on task must remove editing css class', () => {
+        Form.editing = false;
+        Form.domElement = Form.list.tasks[0].domElement;
+        Form.domInput = Form.list.tasks[0].domInput;
+        Form.domSpan = Form.list.tasks[0].domSpan;
+
+        Form.editEvent();
+
+        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
+        Form.list.tasks[0].domInput.dispatchEvent(new KeyboardEvent('keypress', {'key': 'Enter'}));
+        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(false);        
+    });
+});

--- a/src/tests/form.test.js
+++ b/src/tests/form.test.js
@@ -1,11 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import TodoList from "../modules/todoList";
-import Form from "../modules/form";
+import TodoList from "../modules/todoList.js";
+import Form from "../modules/form.js";
 
-document.body.innerHTML =
-  `
+document.body.innerHTML = `
     <div> 
         <ul id="test-list"></ul> 
     </div>
@@ -35,12 +34,12 @@ const testEvent = {
     setData: (key, value) => testEventStorage.set(key, value),
     getData: (key) => testEventStorage.get(key)
   },
-  preventDefault: () => testEventOutput = 1
+  preventDefault: () => testEventOutput = 1,
 };
 
 describe('Optional requirements', () => {
   test('Add event must create new task', () => {
-    const event = { key: 'Enter', type: 'click' }
+    const event = { key: 'Enter', type: 'click' };
 
     Form.addInput = { value: 'just a test' };
     Form.addEvent(event);
@@ -56,7 +55,7 @@ describe('Optional requirements', () => {
   });
 
   test('toggleCompleted event must change task complete status', () => {
-    const event = { key: 'Enter', type: 'click' }
+    const event = { key: 'Enter', type: 'click' };
 
     Form.addInput = { value: 'just a test' };
     Form.addEvent(event);
@@ -65,13 +64,13 @@ describe('Optional requirements', () => {
 
     Form.list.tasks[0].completed = true;
 
-    Form.toggleCompleted(toggleEvent)
+    Form.toggleCompleted(toggleEvent);
 
     expect(Form.list.tasks[0].domCheck.checked).toBe(true);
   });
 
   test('toggleCompleted event must change task complete status', () => {
-    const event = { key: 'Enter', type: 'click' }
+    const event = { key: 'Enter', type: 'click' };
 
     Form.addInput = { value: 'just a test 2' };
     Form.addEvent(event);
@@ -80,7 +79,7 @@ describe('Optional requirements', () => {
 
     Form.list.tasks[0].completed = false;
 
-    Form.toggleCompleted(toggleEvent)
+    Form.toggleCompleted(toggleEvent);
 
     expect(Form.list.tasks[0].domCheck.checked).toBe(false);
   });
@@ -109,11 +108,10 @@ describe('Optional requirements', () => {
     Form.dragTask(testEvent);
 
     expect(testEvent.dataTransfer.getData('index')).toBe(1);
-
   });
 
   test('allowDropTask must prevent Default behavior', () => {
-    Form.allowDropTask(testEvent)
+    Form.allowDropTask(testEvent);
     expect(testEventOutput).toBe(1);
   });
 
@@ -133,7 +131,7 @@ describe('Optional requirements', () => {
     Form.editEvent();
 
     expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
-    Form.list.tasks[0].domInput.dispatchEvent(new KeyboardEvent('keypress', { 'key': 'Enter' } ));
+    Form.list.tasks[0].domInput.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter' }));
     expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(false);
   });
 });

--- a/src/tests/form.test.js
+++ b/src/tests/form.test.js
@@ -35,7 +35,7 @@ const testEvent = {
     setData: (key, value) => testEventStorage.set(key, value),
     getData: (key) => testEventStorage.get(key),
   },
-  preventDefault: () => { testEventOutput = 1 },
+  preventDefault: () => { testEventOutput = 1; },
 };
 
 describe('Optional requirements', () => {

--- a/src/tests/form.test.js
+++ b/src/tests/form.test.js
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import TodoList from "../modules/todoList.js";
-import Form from "../modules/form.js";
+/* eslint-disable no-unused-vars */
+import TodoList from '../modules/todoList.js';
+import Form from '../modules/form.js';
 
 document.body.innerHTML = `
     <div> 
@@ -32,9 +33,9 @@ let testEventOutput = 0;
 const testEvent = {
   dataTransfer: {
     setData: (key, value) => testEventStorage.set(key, value),
-    getData: (key) => testEventStorage.get(key)
+    getData: (key) => testEventStorage.get(key),
   },
-  preventDefault: () => testEventOutput = 1,
+  preventDefault: () => { testEventOutput = 1 },
 };
 
 describe('Optional requirements', () => {

--- a/src/tests/form.test.js
+++ b/src/tests/form.test.js
@@ -31,109 +31,109 @@ const testEventStorage = new Map();
 let testEventOutput = 0;
 
 const testEvent = {
-    dataTransfer: {
-      setData: (key, value) => testEventStorage.set(key, value),
-      getData: (key) => testEventStorage.get(key)
-    },
-    preventDefault: () => testEventOutput = 1
+  dataTransfer: {
+    setData: (key, value) => testEventStorage.set(key, value),
+    getData: (key) => testEventStorage.get(key)
+  },
+  preventDefault: () => testEventOutput = 1
 };
 
 describe('Optional requirements', () => {
-    test('Add event must create new task', () => {
-        const event = { key: 'Enter', type: 'click' }
+  test('Add event must create new task', () => {
+    const event = { key: 'Enter', type: 'click' }
 
-        Form.addInput = { value: 'just a test' };
-        Form.addEvent(event);
-        
-        expect(Form.list.tasks).toHaveLength(1);
-    });
+    Form.addInput = { value: 'just a test' };
+    Form.addEvent(event);
 
-    test('Remove event must remove task', () => {
-        Form.index = 1;
-        Form.removeEvent();
-        
-        expect(Form.list.tasks).toHaveLength(0);
-    });
+    expect(Form.list.tasks).toHaveLength(1);
+  });
 
-    test('toggleCompleted event must change task complete status', () => {
-        const event = { key: 'Enter', type: 'click' }
+  test('Remove event must remove task', () => {
+    Form.index = 1;
+    Form.removeEvent();
 
-        Form.addInput = { value: 'just a test' };
-        Form.addEvent(event);
+    expect(Form.list.tasks).toHaveLength(0);
+  });
 
-        const toggleEvent = { currentTarget: { checked: true } };
+  test('toggleCompleted event must change task complete status', () => {
+    const event = { key: 'Enter', type: 'click' }
 
-        Form.list.tasks[0].completed = true;
+    Form.addInput = { value: 'just a test' };
+    Form.addEvent(event);
 
-        Form.toggleCompleted(toggleEvent)
+    const toggleEvent = { currentTarget: { checked: true } };
 
-        expect(Form.list.tasks[0].domCheck.checked).toBe(true);
-    });
+    Form.list.tasks[0].completed = true;
 
-    test('toggleCompleted event must change task complete status', () => {
-        const event = { key: 'Enter', type: 'click' }
+    Form.toggleCompleted(toggleEvent)
 
-        Form.addInput = { value: 'just a test 2' };
-        Form.addEvent(event);
+    expect(Form.list.tasks[0].domCheck.checked).toBe(true);
+  });
 
-        const toggleEvent = { currentTarget: { checked: false } };
+  test('toggleCompleted event must change task complete status', () => {
+    const event = { key: 'Enter', type: 'click' }
 
-        Form.list.tasks[0].completed = false;
+    Form.addInput = { value: 'just a test 2' };
+    Form.addEvent(event);
 
-        Form.toggleCompleted(toggleEvent)
+    const toggleEvent = { currentTarget: { checked: false } };
 
-        expect(Form.list.tasks[0].domCheck.checked).toBe(false);
-    });
+    Form.list.tasks[0].completed = false;
 
-    test('edit event must add .editing css class', () => {
-        Form.editing = false;
-        Form.domElement = Form.list.tasks[0].domElement;
-        Form.domInput = Form.list.tasks[0].domInput;
-        Form.domSpan = Form.list.tasks[0].domSpan;
+    Form.toggleCompleted(toggleEvent)
 
-        Form.editEvent();
+    expect(Form.list.tasks[0].domCheck.checked).toBe(false);
+  });
 
-        expect(Form.editing).toBe(true);
-        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
-    });
+  test('edit event must add .editing css class', () => {
+    Form.editing = false;
+    Form.domElement = Form.list.tasks[0].domElement;
+    Form.domInput = Form.list.tasks[0].domInput;
+    Form.domSpan = Form.list.tasks[0].domSpan;
 
-    test('edit event must do nothing when already editing', () => {
-        Form.editing = true;
+    Form.editEvent();
 
-        Form.editEvent();
+    expect(Form.editing).toBe(true);
+    expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
+  });
 
-        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
-    });
+  test('edit event must do nothing when already editing', () => {
+    Form.editing = true;
 
-    test('dragTask must set index value', () => {
-        Form.dragTask(testEvent);
+    Form.editEvent();
 
-        expect(testEvent.dataTransfer.getData('index')).toBe(1);
-        
-    });
+    expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
+  });
 
-    test('allowDropTask must prevent Default behavior', () => {
-        Form.allowDropTask(testEvent)
-        expect(testEventOutput).toBe(1);
-    });
+  test('dragTask must set index value', () => {
+    Form.dragTask(testEvent);
 
-    test('dropTask must switch item index', () => {
-        Form.index = 2;
-        Form.dropTask(testEvent);
-        expect(Form.list.tasks[0].description).toBe('just a test 2');     
-        expect(Form.list.tasks[1].description).toBe('just a test');     
-    });
+    expect(testEvent.dataTransfer.getData('index')).toBe(1);
 
-    test('keypress enter event on task must remove editing css class', () => {
-        Form.editing = false;
-        Form.domElement = Form.list.tasks[0].domElement;
-        Form.domInput = Form.list.tasks[0].domInput;
-        Form.domSpan = Form.list.tasks[0].domSpan;
+  });
 
-        Form.editEvent();
+  test('allowDropTask must prevent Default behavior', () => {
+    Form.allowDropTask(testEvent)
+    expect(testEventOutput).toBe(1);
+  });
 
-        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
-        Form.list.tasks[0].domInput.dispatchEvent(new KeyboardEvent('keypress', {'key': 'Enter'}));
-        expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(false);        
-    });
+  test('dropTask must switch item index', () => {
+    Form.index = 2;
+    Form.dropTask(testEvent);
+    expect(Form.list.tasks[0].description).toBe('just a test 2');
+    expect(Form.list.tasks[1].description).toBe('just a test');
+  });
+
+  test('keypress enter event on task must remove editing css class', () => {
+    Form.editing = false;
+    Form.domElement = Form.list.tasks[0].domElement;
+    Form.domInput = Form.list.tasks[0].domInput;
+    Form.domSpan = Form.list.tasks[0].domSpan;
+
+    Form.editEvent();
+
+    expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(true);
+    Form.list.tasks[0].domInput.dispatchEvent(new KeyboardEvent('keypress', { 'key': 'Enter' } ));
+    expect(Form.list.tasks[0].domElement.classList.contains('editing')).toBe(false);
+  });
 });

--- a/src/tests/todoList.test.js
+++ b/src/tests/todoList.test.js
@@ -52,4 +52,16 @@ describe('Testing To Do list: part 2', () => {
   
     expect(myList.tasks[0].description).toBe('New value');
   });
+    test('Complete one item in the list', () => {
+    myList.completeTask(myList.tasks[0]);
+  
+    expect(myList.tasks[0].completed).toBe(true);
+  });
+  
+  test('Clear all completed item to the list', () => {
+    myList.clearAllCompleted();
+  
+    const list = document.querySelectorAll('#test-list li');
+    expect(list).toHaveLength(0);
+  });
 })

--- a/src/tests/todoList.test.js
+++ b/src/tests/todoList.test.js
@@ -41,3 +41,15 @@ describe('Testing To Do list: part 1', () => {
     expect(list).toHaveLength(0);
   });
 });
+
+describe('Testing To Do list: part 2', () => {
+  test('Edit one item to the list', () => {
+    myList.addTask('Test description');
+  
+    myList.tasks[0].domInput.value = 'New value';
+  
+    myList.editTask(myList.tasks[0]);
+  
+    expect(myList.tasks[0].description).toBe('New value');
+  });
+})

--- a/src/tests/todoList.test.js
+++ b/src/tests/todoList.test.js
@@ -45,23 +45,82 @@ describe('Testing To Do list: part 1', () => {
 describe('Testing To Do list: part 2', () => {
   test('Edit one item to the list', () => {
     myList.addTask('Test description');
-  
     myList.tasks[0].domInput.value = 'New value';
-  
     myList.editTask(myList.tasks[0]);
-  
+
     expect(myList.tasks[0].description).toBe('New value');
   });
-    test('Complete one item in the list', () => {
+  test('Complete one item in the list', () => {
     myList.completeTask(myList.tasks[0]);
-  
+
     expect(myList.tasks[0].completed).toBe(true);
   });
-  
+
   test('Clear all completed item to the list', () => {
     myList.clearAllCompleted();
-  
+
     const list = document.querySelectorAll('#test-list li');
     expect(list).toHaveLength(0);
   });
-})
+});
+
+describe('Optional requirements', () => {
+  test('Uncomplete one item in the list', () => {
+    myList.addTask('Test description', true);
+
+    myList.uncompleteTask(myList.tasks[0]);
+
+    expect(myList.tasks[0].completed).toBe(false);
+  });
+
+  test('Switching item indexes in the list', () => {
+    myList.addTask('Test description 2', true);
+    myList.addTask('Test description 3', true);
+
+    myList.switchIndexes(1, 4);
+
+    expect(myList.tasks[0].description).toBe('Test description 2');
+    expect(myList.tasks[2].description).toBe('Test description');
+  });
+
+  test('Edit item with empty string', () => {
+    myList.tasks[0].domInput.value = '';
+
+    myList.editTask(myList.tasks[0]);
+
+    expect(myList.tasks[0].description).toBe('Test description 2');
+  });
+
+  test('Load items from local storage', () => {
+    const myNewList = new TodoList('#test-list');
+
+    myNewList.tasks = [];
+
+    const myNewForm = new Form(myNewList, {
+      newTaskInput: 'new_task_input',
+      newTaskIcon: 'new_task_icon',
+      clearAllCompletedTasks: 'clear_all_completed_tasks',
+    });
+
+    expect(myNewList.tasks).toHaveLength(3);
+  });
+
+  test('Load items from empty local storage', () => {
+    myList.removeTask(1);
+    myList.removeTask(1);
+    myList.removeTask(1);
+    myList.drawTable();
+
+    const myNewList = new TodoList('#test-list');
+
+    myNewList.tasks = [];
+
+    const myNewForm = new Form(myNewList, {
+      newTaskInput: 'new_task_input',
+      newTaskIcon: 'new_task_icon',
+      clearAllCompletedTasks: 'clear_all_completed_tasks',
+    });
+
+    expect(myNewList.tasks).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Testing To Do list: part 2

In this PR, we created these tests:

### Mandatory:

- Edit one item in the list
- Complete one item in the list
- Clear all completed items in the list

### Optional:

- Uncomplete one item in the list
- Switching item indexes in the list
- Edit item with an empty string
- Load items from local storage
- Load items from empty local storage
- Add event must create new task
- Remove event must remove task
- `toggleCompleted` event must change task complete status
- `toggleCompleted` event must change task complete status
- edit event must add `.editing` css class
- edit event must do nothing when already editing
- `dragTask` must set index value
- `allowDropTask` must prevent Default behavior
- `dropTask` must switch item index
- `keypress` enter event on task must remove `.editing` css class